### PR TITLE
feat: add basic BBS skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # BitsBlog
-asp.net core webapi + ef +react +bits ui
+
+ASP.NET Core 8 WebAPI + Entity Framework + React + Bits UI 예제. 클린 아키텍처를 기반으로 한 간단한 게시판(BBS) 구현입니다.
+
+## 프로젝트 구조
+
+- `src/Domain` - 도메인 엔터티
+- `src/Application` - 서비스 및 인터페이스
+- `src/Infrastructure` - EF Core DbContext 및 리포지토리
+- `src/WebApi` - REST API
+- `src/MvcClient` - ASP.NET Core MVC 클라이언트
+- `client-react` - React + Bits UI 클라이언트 샘플
+
+## 실행
+
+```bash
+# Web API
+cd src/WebApi
+# dotnet run
+
+# MVC 클라이언트
+cd src/MvcClient
+# dotnet run
+
+# React 클라이언트 (예: Vite 등으로 빌드)
+cd client-react
+# npm install && npm run dev
+```
+
+현재 환경에서는 .NET SDK가 설치되어 있지 않으므로 `dotnet` 명령이 실행되지 않을 수 있습니다.

--- a/client-react/index.html
+++ b/client-react/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>BitsBlog React</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/client-react/package.json
+++ b/client-react/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "bitsblog-client",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "bits-ui": "^1.0.0"
+  }
+}

--- a/client-react/src/App.jsx
+++ b/client-react/src/App.jsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import { Button } from 'bits-ui';
+
+export default function App() {
+  const [posts, setPosts] = useState([]);
+  useEffect(() => {
+    fetch('/api/posts')
+      .then(res => res.json())
+      .then(setPosts);
+  }, []);
+  return (
+    <div>
+      <h1>게시판 (React)</h1>
+      {posts.map(p => (
+        <div key={p.id}>
+          <h3>{p.title}</h3>
+          <p>{p.content}</p>
+        </div>
+      ))}
+      <Button>Bits UI 버튼</Button>
+    </div>
+  );
+}

--- a/client-react/src/main.jsx
+++ b/client-react/src/main.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/src/Application/DTOs/PostDto.cs
+++ b/src/Application/DTOs/PostDto.cs
@@ -1,0 +1,6 @@
+using System;
+
+namespace BitsBlog.Application.DTOs
+{
+    public record PostDto(int Id, string Title, string Content, DateTime Created);
+}

--- a/src/Application/Interfaces/IPostRepository.cs
+++ b/src/Application/Interfaces/IPostRepository.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BitsBlog.Domain.Entities;
+
+namespace BitsBlog.Application.Interfaces
+{
+    public interface IPostRepository
+    {
+        Task<IEnumerable<Post>> GetAllAsync();
+        Task<Post?> GetByIdAsync(int id);
+        Task<Post> AddAsync(Post post);
+    }
+}

--- a/src/Application/Services/PostService.cs
+++ b/src/Application/Services/PostService.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BitsBlog.Application.DTOs;
+using BitsBlog.Application.Interfaces;
+using BitsBlog.Domain.Entities;
+
+namespace BitsBlog.Application.Services
+{
+    public class PostService
+    {
+        private readonly IPostRepository _repository;
+        public PostService(IPostRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task<IEnumerable<PostDto>> GetPostsAsync()
+        {
+            var posts = await _repository.GetAllAsync();
+            return posts.Select(p => new PostDto(p.Id, p.Title, p.Content, p.Created));
+        }
+
+        public async Task<PostDto> CreateAsync(string title, string content)
+        {
+            var post = await _repository.AddAsync(new Post { Title = title, Content = content });
+            return new PostDto(post.Id, post.Title, post.Content, post.Created);
+        }
+    }
+}

--- a/src/Domain/Entities/Post.cs
+++ b/src/Domain/Entities/Post.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace BitsBlog.Domain.Entities
+{
+    public class Post
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public string Content { get; set; } = string.Empty;
+        public DateTime Created { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/src/Infrastructure/BitsBlogDbContext.cs
+++ b/src/Infrastructure/BitsBlogDbContext.cs
@@ -1,0 +1,12 @@
+using Microsoft.EntityFrameworkCore;
+using BitsBlog.Domain.Entities;
+
+namespace BitsBlog.Infrastructure
+{
+    public class BitsBlogDbContext : DbContext
+    {
+        public BitsBlogDbContext(DbContextOptions<BitsBlogDbContext> options) : base(options) { }
+
+        public DbSet<Post> Posts => Set<Post>();
+    }
+}

--- a/src/Infrastructure/Repositories/PostRepository.cs
+++ b/src/Infrastructure/Repositories/PostRepository.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BitsBlog.Application.Interfaces;
+using BitsBlog.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace BitsBlog.Infrastructure.Repositories
+{
+    public class PostRepository : IPostRepository
+    {
+        private readonly BitsBlogDbContext _context;
+        public PostRepository(BitsBlogDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<Post> AddAsync(Post post)
+        {
+            _context.Posts.Add(post);
+            await _context.SaveChangesAsync();
+            return post;
+        }
+
+        public async Task<IEnumerable<Post>> GetAllAsync()
+        {
+            return await _context.Posts.OrderByDescending(p => p.Created).ToListAsync();
+        }
+
+        public async Task<Post?> GetByIdAsync(int id)
+        {
+            return await _context.Posts.FindAsync(id);
+        }
+    }
+}

--- a/src/MvcClient/Controllers/HomeController.cs
+++ b/src/MvcClient/Controllers/HomeController.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using BitsBlog.Application.DTOs;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BitsBlog.MvcClient.Controllers
+{
+    public class HomeController : Controller
+    {
+        private readonly IHttpClientFactory _clientFactory;
+        public HomeController(IHttpClientFactory clientFactory)
+        {
+            _clientFactory = clientFactory;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            var client = _clientFactory.CreateClient("api");
+            var posts = await client.GetFromJsonAsync<IEnumerable<PostDto>>("posts");
+            return View(posts);
+        }
+    }
+}

--- a/src/MvcClient/Controllers/PostsController.cs
+++ b/src/MvcClient/Controllers/PostsController.cs
@@ -1,0 +1,27 @@
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using BitsBlog.MvcClient.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BitsBlog.MvcClient.Controllers
+{
+    public class PostsController : Controller
+    {
+        private readonly IHttpClientFactory _clientFactory;
+        public PostsController(IHttpClientFactory clientFactory)
+        {
+            _clientFactory = clientFactory;
+        }
+
+        public IActionResult Create() => View();
+
+        [HttpPost]
+        public async Task<IActionResult> Create(CreatePostViewModel model)
+        {
+            if (!ModelState.IsValid) return View(model);
+            var client = _clientFactory.CreateClient("api");
+            await client.PostAsJsonAsync("posts", new { model.Title, model.Content });
+            return RedirectToAction("Index", "Home");
+        }
+    }
+}

--- a/src/MvcClient/Models/CreatePostViewModel.cs
+++ b/src/MvcClient/Models/CreatePostViewModel.cs
@@ -1,0 +1,8 @@
+namespace BitsBlog.MvcClient.Models
+{
+    public class CreatePostViewModel
+    {
+        public string Title { get; set; } = string.Empty;
+        public string Content { get; set; } = string.Empty;
+    }
+}

--- a/src/MvcClient/Program.cs
+++ b/src/MvcClient/Program.cs
@@ -1,0 +1,15 @@
+using System;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllersWithViews();
+builder.Services.AddHttpClient("api", client =>
+{
+    client.BaseAddress = new Uri("http://localhost:5000/api/");
+});
+
+var app = builder.Build();
+app.UseStaticFiles();
+app.UseRouting();
+app.MapDefaultControllerRoute();
+app.Run();

--- a/src/MvcClient/Views/Home/Index.cshtml
+++ b/src/MvcClient/Views/Home/Index.cshtml
@@ -1,0 +1,13 @@
+@model IEnumerable<BitsBlog.Application.DTOs.PostDto>
+
+<h1>게시판</h1>
+<a href="/Posts/Create">글쓰기</a>
+<ul>
+@foreach (var post in Model)
+{
+    <li>
+        <h3>@post.Title (@post.Created.ToLocalTime())</h3>
+        <p>@post.Content</p>
+    </li>
+}
+</ul>

--- a/src/MvcClient/Views/Posts/Create.cshtml
+++ b/src/MvcClient/Views/Posts/Create.cshtml
@@ -1,0 +1,13 @@
+@model BitsBlog.MvcClient.Models.CreatePostViewModel
+<h1>글쓰기</h1>
+<form asp-action="Create" method="post">
+    <div>
+        <label asp-for="Title"></label>
+        <input asp-for="Title" />
+    </div>
+    <div>
+        <label asp-for="Content"></label>
+        <textarea asp-for="Content"></textarea>
+    </div>
+    <button type="submit">저장</button>
+</form>

--- a/src/WebApi/Controllers/PostsController.cs
+++ b/src/WebApi/Controllers/PostsController.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BitsBlog.Application.DTOs;
+using BitsBlog.Application.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BitsBlog.WebApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class PostsController : ControllerBase
+    {
+        private readonly PostService _service;
+        public PostsController(PostService service)
+        {
+            _service = service;
+        }
+
+        [HttpGet]
+        public async Task<IEnumerable<PostDto>> Get() => await _service.GetPostsAsync();
+
+        [HttpPost]
+        public async Task<ActionResult<PostDto>> Post([FromBody] CreatePostRequest request)
+        {
+            var post = await _service.CreateAsync(request.Title, request.Content);
+            return CreatedAtAction(nameof(Get), new { id = post.Id }, post);
+        }
+
+        public record CreatePostRequest(string Title, string Content);
+    }
+}

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -1,0 +1,27 @@
+using BitsBlog.Application.Interfaces;
+using BitsBlog.Application.Services;
+using BitsBlog.Infrastructure;
+using BitsBlog.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddDbContext<BitsBlogDbContext>(opt => opt.UseInMemoryDatabase("BitsBlog"));
+builder.Services.AddScoped<IPostRepository, PostRepository>();
+builder.Services.AddScoped<PostService>();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseRouting();
+app.UseAuthorization();
+app.MapControllers();
+app.Run();


### PR DESCRIPTION
## Summary
- implement Clean Architecture structure for simple BBS
- add WebAPI with EF Core InMemory and Posts endpoint
- add ASP.NET Core MVC and React + Bits UI clients

## Testing
- `dotnet build src/WebApi` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b6dd2ce840832f997c31457d3b6bb4