### PR TITLE
Use SQL Server and add initial EF migration

### DIFF
--- a/src/BitsBlog.Infrastructure/BitsBlog.Infrastructure.csproj
+++ b/src/BitsBlog.Infrastructure/BitsBlog.Infrastructure.csproj
@@ -10,6 +10,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/BitsBlog.Infrastructure/Migrations/20240629000000_InitialCreate.cs
+++ b/src/BitsBlog.Infrastructure/Migrations/20240629000000_InitialCreate.cs
@@ -1,0 +1,38 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BitsBlog.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class InitialCreate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Posts",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Title = table.Column<string>(nullable: false),
+                    Content = table.Column<string>(nullable: false),
+                    Created = table.Column<DateTime>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Posts", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Posts");
+        }
+    }
+}
+

--- a/src/BitsBlog.Infrastructure/Migrations/BitsBlogDbContextModelSnapshot.cs
+++ b/src/BitsBlog.Infrastructure/Migrations/BitsBlogDbContextModelSnapshot.cs
@@ -1,0 +1,45 @@
+using System;
+using BitsBlog.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+#nullable disable
+
+namespace BitsBlog.Infrastructure.Migrations
+{
+    [DbContext(typeof(BitsBlogDbContext))]
+    partial class BitsBlogDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "8.0.0");
+
+            modelBuilder.Entity("BitsBlog.Domain.Entities.Post", b =>
+            {
+                b.Property<int>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("int")
+                    .HasAnnotation("SqlServer:Identity", "1, 1");
+
+                b.Property<string>("Content")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<DateTime>("Created")
+                    .HasColumnType("datetime2");
+
+                b.Property<string>("Title")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(max)");
+
+                b.HasKey("Id");
+
+                b.ToTable("Posts");
+            });
+        }
+    }
+}
+

--- a/src/BitsBlog.WebApi/Program.cs
+++ b/src/BitsBlog.WebApi/Program.cs
@@ -3,17 +3,27 @@ using BitsBlog.Application.Services;
 using BitsBlog.Infrastructure;
 using BitsBlog.Infrastructure.Repositories;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
-builder.Services.AddDbContext<BitsBlogDbContext>(opt => opt.UseInMemoryDatabase("BitsBlog"));
+
+var connectionString = "Server=(local);Database=BitsBlogDb;User Id=sa;Password=123456;TrustServerCertificate=True";
+builder.Services.AddDbContext<BitsBlogDbContext>(opt =>
+    opt.UseSqlServer(connectionString));
 builder.Services.AddScoped<IPostRepository, PostRepository>();
 builder.Services.AddScoped<PostService>();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<BitsBlogDbContext>();
+    db.Database.Migrate();
+}
 
 if (app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
## Summary
- configure WebAPI to use SQL Server with connection string
- add SQL Server EF Core provider and initial migrations for Posts table

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b6e7692ba8832f9ac06d3dd2718ed8