### PR TITLE
Add design-time DbContext factory

### DIFF
--- a/src/BitsBlog.Infrastructure/BitsBlog.Infrastructure.csproj
+++ b/src/BitsBlog.Infrastructure/BitsBlog.Infrastructure.csproj
@@ -15,5 +15,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/BitsBlog.Infrastructure/BitsBlogDbContextFactory.cs
+++ b/src/BitsBlog.Infrastructure/BitsBlogDbContextFactory.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.IO;
+
+namespace BitsBlog.Infrastructure
+{
+    public class BitsBlogDbContextFactory : IDesignTimeDbContextFactory<BitsBlogDbContext>
+    {
+        public BitsBlogDbContext CreateDbContext(string[] args)
+        {
+            var basePath = Directory.GetCurrentDirectory();
+
+            var configuration = new ConfigurationBuilder()
+                .SetBasePath(basePath)
+                .AddJsonFile("appsettings.json", optional: true)
+                .AddEnvironmentVariables()
+                .Build();
+
+            var connectionString = configuration.GetConnectionString("DefaultConnection");
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
+            }
+
+            var options = new DbContextOptionsBuilder<BitsBlogDbContext>()
+                .UseSqlServer(connectionString)
+                .Options;
+
+            return new BitsBlogDbContext(options);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `BitsBlogDbContextFactory` for design-time migrations
- load DefaultConnection from appsettings and environment
- add configuration packages required for factory

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b6feeb4a48832fb642051b5d0fb756