### PR TITLE
WebApi 연결 문자열을 설정 파일로 분리

### DIFF
--- a/src/BitsBlog.WebApi/Program.cs
+++ b/src/BitsBlog.WebApi/Program.cs
@@ -9,9 +9,8 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllers();
 
-var connectionString = "Server=(local);Database=BitsBlog;User Id=sa;Password=123456;TrustServerCertificate=True";
 builder.Services.AddDbContext<BitsBlogDbContext>(opt =>
-    opt.UseSqlServer(connectionString));
+    opt.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
 builder.Services.AddScoped<IPostRepository, PostRepository>();
 builder.Services.AddScoped<PostService>();
 builder.Services.AddEndpointsApiExplorer();

--- a/src/BitsBlog.WebApi/appsettings.json
+++ b/src/BitsBlog.WebApi/appsettings.json
@@ -1,0 +1,5 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(local);Database=BitsBlog;User Id=sa;Password=123456;TrustServerCertificate=True"
+  }
+}


### PR DESCRIPTION
## Summary
- appsettings.json을 추가하여 연결 문자열을 관리하도록 구성
- Program.cs에서 연결 문자열을 설정에서 읽도록 변경

## Testing
- `dotnet build` *(실패: dotnet 명령어 없음)*
- `apt-get update` *(실패: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b700d13e78832fb067214b8350f645