### PR TITLE
feat: add Comment table via EF Core

### DIFF
--- a/src/BitsBlog.Domain/Entities/Comment.cs
+++ b/src/BitsBlog.Domain/Entities/Comment.cs
@@ -1,15 +1,14 @@
 using System;
-using System.Collections.Generic;
 
 namespace BitsBlog.Domain.Entities
 {
-    public class Post
+    public class Comment
     {
         public int Id { get; set; }
-        public string Title { get; set; } = string.Empty;
+        public int PostId { get; set; }
         public string Content { get; set; } = string.Empty;
         public DateTime Created { get; set; } = DateTime.UtcNow;
 
-        public ICollection<Comment> Comments { get; set; } = new List<Comment>();
+        public Post Post { get; set; } = null!;
     }
 }

--- a/src/BitsBlog.Infrastructure/BitsBlogDbContext.cs
+++ b/src/BitsBlog.Infrastructure/BitsBlogDbContext.cs
@@ -8,5 +8,6 @@ namespace BitsBlog.Infrastructure
         public BitsBlogDbContext(DbContextOptions<BitsBlogDbContext> options) : base(options) { }
 
         public DbSet<Post> Posts => Set<Post>();
+        public DbSet<Comment> Comments => Set<Comment>();
     }
 }

--- a/src/BitsBlog.Infrastructure/Migrations/20240902000000_AddCommentsTable.cs
+++ b/src/BitsBlog.Infrastructure/Migrations/20240902000000_AddCommentsTable.cs
@@ -1,0 +1,48 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BitsBlog.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCommentsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Comments",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    PostId = table.Column<int>(nullable: false),
+                    Content = table.Column<string>(nullable: false),
+                    Created = table.Column<DateTime>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Comments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Comments_Posts_PostId",
+                        column: x => x.PostId,
+                        principalTable: "Posts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Comments_PostId",
+                table: "Comments",
+                column: "PostId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Comments");
+        }
+    }
+}

--- a/src/BitsBlog.Infrastructure/Migrations/BitsBlogDbContextModelSnapshot.cs
+++ b/src/BitsBlog.Infrastructure/Migrations/BitsBlogDbContextModelSnapshot.cs
@@ -17,6 +17,30 @@ namespace BitsBlog.Infrastructure.Migrations
             modelBuilder
                 .HasAnnotation("ProductVersion", "8.0.0");
 
+            modelBuilder.Entity("BitsBlog.Domain.Entities.Comment", b =>
+            {
+                b.Property<int>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("int")
+                    .HasAnnotation("SqlServer:Identity", "1, 1");
+
+                b.Property<string>("Content")
+                    .IsRequired()
+                    .HasColumnType("nvarchar(max)");
+
+                b.Property<DateTime>("Created")
+                    .HasColumnType("datetime2");
+
+                b.Property<int>("PostId")
+                    .HasColumnType("int");
+
+                b.HasKey("Id");
+
+                b.HasIndex("PostId");
+
+                b.ToTable("Comments");
+            });
+
             modelBuilder.Entity("BitsBlog.Domain.Entities.Post", b =>
             {
                 b.Property<int>("Id")
@@ -38,6 +62,22 @@ namespace BitsBlog.Infrastructure.Migrations
                 b.HasKey("Id");
 
                 b.ToTable("Posts");
+            });
+
+            modelBuilder.Entity("BitsBlog.Domain.Entities.Comment", b =>
+            {
+                b.HasOne("BitsBlog.Domain.Entities.Post", "Post")
+                    .WithMany("Comments")
+                    .HasForeignKey("PostId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("Post");
+            });
+
+            modelBuilder.Entity("BitsBlog.Domain.Entities.Post", b =>
+            {
+                b.Navigation("Comments");
             });
         }
     }


### PR DESCRIPTION
## Summary
- add Comment entity and relationship to Post
- extend BitsBlogDbContext with Comments DbSet
- create EF Core migration for Comments table

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b703728fdc832fab83c300adc7365f