### PR TITLE
Use WebApi to list posts in web and react clients

### DIFF
--- a/client-react/src/components/PostsList.tsx
+++ b/client-react/src/components/PostsList.tsx
@@ -9,7 +9,7 @@ export function PostsList({ posts }: PostsListProps) {
     <div>
       {posts.map(p => (
         <article key={p.id}>
-          <h3>{p.title}</h3>
+          <h3>{p.title} ({new Date(p.created).toLocaleString()})</h3>
           <p>{p.content}</p>
         </article>
       ))}

--- a/client-react/src/hooks/usePosts.ts
+++ b/client-react/src/hooks/usePosts.ts
@@ -4,13 +4,14 @@ export interface Post {
   id: number;
   title: string;
   content: string;
+  created: string;
 }
 
 export function usePosts() {
   const [posts, setPosts] = useState<Post[]>([]);
 
   useEffect(() => {
-    fetch('/api/posts')
+    fetch('http://localhost:52015/api/posts')
       .then(res => res.json() as Promise<Post[]>)
       .then(setPosts);
   }, []);

--- a/src/BitsBlog.Web/Controllers/HomeController.cs
+++ b/src/BitsBlog.Web/Controllers/HomeController.cs
@@ -1,25 +1,9 @@
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Net.Http.Json;
-using System.Threading.Tasks;
-using BitsBlog.Application.DTOs;
 using Microsoft.AspNetCore.Mvc;
 
 namespace BitsBlog.Web.Controllers
 {
     public class HomeController : Controller
     {
-        private readonly IHttpClientFactory _clientFactory;
-        public HomeController(IHttpClientFactory clientFactory)
-        {
-            _clientFactory = clientFactory;
-        }
-
-        public async Task<IActionResult> Index()
-        {
-            var client = _clientFactory.CreateClient("api");
-            var posts = await client.GetFromJsonAsync<IEnumerable<PostDto>>("posts");
-            return View(posts);
-        }
+        public IActionResult Index() => RedirectToAction("Index", "Posts");
     }
 }

--- a/src/BitsBlog.Web/Controllers/PostsController.cs
+++ b/src/BitsBlog.Web/Controllers/PostsController.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
+using BitsBlog.Application.DTOs;
 using BitsBlog.Web.Models;
 using Microsoft.AspNetCore.Mvc;
 
@@ -11,6 +13,13 @@ namespace BitsBlog.Web.Controllers
         public PostsController(IHttpClientFactory clientFactory)
         {
             _clientFactory = clientFactory;
+        }
+
+        public async Task<IActionResult> Index()
+        {
+            var client = _clientFactory.CreateClient("api");
+            var posts = await client.GetFromJsonAsync<IEnumerable<PostDto>>("posts");
+            return View(posts);
         }
 
         public IActionResult Create() => View();

--- a/src/BitsBlog.Web/Views/Posts/Index.cshtml
+++ b/src/BitsBlog.Web/Views/Posts/Index.cshtml
@@ -1,0 +1,13 @@
+@model IEnumerable<BitsBlog.Application.DTOs.PostDto>
+
+<h1>게시판</h1>
+<a href="/Posts/Create">글쓰기</a>
+<ul>
+@foreach (var post in Model)
+{
+    <li>
+        <h3>@post.Title (@post.Created.ToLocalTime())</h3>
+        <p>@post.Content</p>
+    </li>
+}
+</ul>


### PR DESCRIPTION
## Summary
- Fetch posts from WebApi in PostsController and display them in new Posts/Index view
- Redirect HomeController to posts listing
- Retrieve and render posts in React client, including creation time

## Testing
- `dotnet test` *(fails: command not found)*
- `npm test` *(fails: missing script)*
- `npm run build` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_b_68b70da25574832fa6912d8ee0331a17