### PR TITLE
test: add controller tests

### DIFF
--- a/BitsBlog.sln
+++ b/BitsBlog.sln
@@ -12,6 +12,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BitsBlog.WebApi", "src\Bits
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BitsBlog.Web", "src\BitsBlog.Web\BitsBlog.Web.csproj", "{CC68D029-73CD-4135-A986-83EC8DE93C79}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BitsBlog.WebApi.Tests", "tests\BitsBlog.WebApi.Tests\BitsBlog.WebApi.Tests.csproj", "{CEEB7ED4-384D-4C9E-89EE-2CC0E7959626}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BitsBlog.Web.Tests", "tests\BitsBlog.Web.Tests\BitsBlog.Web.Tests.csproj", "{91B531E9-D01A-4F68-A165-A7D48A32024C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -34,11 +38,19 @@ Global
 		{34046527-CA48-4541-AE97-5960572A0CBE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{34046527-CA48-4541-AE97-5960572A0CBE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{34046527-CA48-4541-AE97-5960572A0CBE}.Release|Any CPU.Build.0 = Release|Any CPU
-		{CC68D029-73CD-4135-A986-83EC8DE93C79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{CC68D029-73CD-4135-A986-83EC8DE93C79}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{CC68D029-73CD-4135-A986-83EC8DE93C79}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{CC68D029-73CD-4135-A986-83EC8DE93C79}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {CC68D029-73CD-4135-A986-83EC8DE93C79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {CC68D029-73CD-4135-A986-83EC8DE93C79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {CC68D029-73CD-4135-A986-83EC8DE93C79}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {CC68D029-73CD-4135-A986-83EC8DE93C79}.Release|Any CPU.Build.0 = Release|Any CPU
+                {CEEB7ED4-384D-4C9E-89EE-2CC0E7959626}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {CEEB7ED4-384D-4C9E-89EE-2CC0E7959626}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {CEEB7ED4-384D-4C9E-89EE-2CC0E7959626}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {CEEB7ED4-384D-4C9E-89EE-2CC0E7959626}.Release|Any CPU.Build.0 = Release|Any CPU
+                {91B531E9-D01A-4F68-A165-A7D48A32024C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {91B531E9-D01A-4F68-A165-A7D48A32024C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {91B531E9-D01A-4F68-A165-A7D48A32024C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {91B531E9-D01A-4F68-A165-A7D48A32024C}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/tests/BitsBlog.Web.Tests/BitsBlog.Web.Tests.csproj
+++ b/tests/BitsBlog.Web.Tests/BitsBlog.Web.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.69" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\BitsBlog.Web\BitsBlog.Web.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/BitsBlog.Web.Tests/HomeControllerTests.cs
+++ b/tests/BitsBlog.Web.Tests/HomeControllerTests.cs
@@ -1,0 +1,21 @@
+using BitsBlog.Web.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace BitsBlog.Web.Tests
+{
+    public class HomeControllerTests
+    {
+        [Fact]
+        public void Index_RedirectsToPostsIndex()
+        {
+            var controller = new HomeController();
+
+            var result = controller.Index();
+
+            var redirect = Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", redirect.ActionName);
+            Assert.Equal("Posts", redirect.ControllerName);
+        }
+    }
+}

--- a/tests/BitsBlog.Web.Tests/PostsControllerTests.cs
+++ b/tests/BitsBlog.Web.Tests/PostsControllerTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BitsBlog.Application.DTOs;
+using BitsBlog.Web.Controllers;
+using BitsBlog.Web.Models;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace BitsBlog.Web.Tests
+{
+    public class PostsControllerTests
+    {
+        [Fact]
+        public async Task Index_ReturnsViewWithPosts()
+        {
+            var posts = new[] { new PostDto(1, "t", "c", DateTime.UtcNow) };
+            var json = JsonSerializer.Serialize(posts);
+            var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            });
+            var client = new HttpClient(handler);
+            var factory = new Mock<IHttpClientFactory>();
+            factory.Setup(f => f.CreateClient("api")).Returns(client);
+            var controller = new PostsController(factory.Object);
+
+            var result = await controller.Index();
+
+            var view = Assert.IsType<ViewResult>(result);
+            var model = Assert.IsAssignableFrom<IEnumerable<PostDto>>(view.Model);
+            Assert.Equal(posts, model);
+        }
+
+        [Fact]
+        public void Create_Get_ReturnsView()
+        {
+            var controller = new PostsController(new Mock<IHttpClientFactory>().Object);
+
+            var result = controller.Create();
+
+            Assert.IsType<ViewResult>(result);
+        }
+
+        [Fact]
+        public async Task Create_Post_InvalidModel_ReturnsViewWithModel()
+        {
+            var controller = new PostsController(new Mock<IHttpClientFactory>().Object);
+            controller.ModelState.AddModelError("Title", "Required");
+            var model = new CreatePostViewModel { Title = "", Content = "content" };
+
+            var result = await controller.Create(model);
+
+            var view = Assert.IsType<ViewResult>(result);
+            Assert.Equal(model, view.Model);
+        }
+
+        [Fact]
+        public async Task Create_Post_ValidModel_RedirectsToHomeIndex()
+        {
+            var handler = new FakeHttpMessageHandler(new HttpResponseMessage(HttpStatusCode.Created));
+            var client = new HttpClient(handler);
+            var factory = new Mock<IHttpClientFactory>();
+            factory.Setup(f => f.CreateClient("api")).Returns(client);
+            var controller = new PostsController(factory.Object);
+            var model = new CreatePostViewModel { Title = "t", Content = "c" };
+
+            var result = await controller.Create(model);
+
+            var redirect = Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal("Index", redirect.ActionName);
+            Assert.Equal("Home", redirect.ControllerName);
+        }
+
+        private class FakeHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly HttpResponseMessage _response;
+            public HttpRequestMessage? Request { get; private set; }
+
+            public FakeHttpMessageHandler(HttpResponseMessage response)
+            {
+                _response = response;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Request = request;
+                return Task.FromResult(_response);
+            }
+        }
+    }
+}

--- a/tests/BitsBlog.WebApi.Tests/BitsBlog.WebApi.Tests.csproj
+++ b/tests/BitsBlog.WebApi.Tests/BitsBlog.WebApi.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.69" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\BitsBlog.WebApi\BitsBlog.WebApi.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/BitsBlog.WebApi.Tests/PostsControllerTests.cs
+++ b/tests/BitsBlog.WebApi.Tests/PostsControllerTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BitsBlog.Application.DTOs;
+using BitsBlog.Application.Interfaces;
+using BitsBlog.Application.Services;
+using BitsBlog.Domain.Entities;
+using BitsBlog.WebApi.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace BitsBlog.WebApi.Tests
+{
+    public class PostsControllerTests
+    {
+        [Fact]
+        public async Task Get_ReturnsPostsFromService()
+        {
+            var posts = new[]
+            {
+                new Post { Id = 1, Title = "Title1", Content = "Content1", Created = DateTime.UtcNow },
+                new Post { Id = 2, Title = "Title2", Content = "Content2", Created = DateTime.UtcNow }
+            };
+            var repo = new Mock<IPostRepository>();
+            repo.Setup(r => r.GetAllAsync()).ReturnsAsync(posts);
+            var service = new PostService(repo.Object);
+            var controller = new PostsController(service);
+
+            var result = await controller.Get();
+
+            Assert.Equal(posts.Select(p => new PostDto(p.Id, p.Title, p.Content, p.Created)), result);
+        }
+
+        [Fact]
+        public async Task Post_ReturnsCreatedPost()
+        {
+            var post = new Post { Id = 1, Title = "New", Content = "Body", Created = DateTime.UtcNow };
+            var repo = new Mock<IPostRepository>();
+            repo.Setup(r => r.AddAsync(It.IsAny<Post>())).ReturnsAsync(post);
+            var service = new PostService(repo.Object);
+            var controller = new PostsController(service);
+            var request = new PostsController.CreatePostRequest(post.Title, post.Content);
+
+            var response = await controller.Post(request);
+
+            var created = Assert.IsType<CreatedAtActionResult>(response.Result);
+            var dto = Assert.IsType<PostDto>(created.Value);
+            Assert.Equal(post.Id, dto.Id);
+            Assert.Equal(post.Title, dto.Title);
+            Assert.Equal(post.Content, dto.Content);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for WebApi PostsController
- add MVC controller tests for home and posts controllers

## Testing
- `dotnet test` (fails: command not found)

------
https://chatgpt.com/codex/tasks/task_b_68b71683655c832f9742cc84b7f66c26