### PR TITLE
feat: configure API URL via env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:52015

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ cd src/BitsBlog.Web
 
 # React 클라이언트 (예: Vite 등으로 빌드)
 cd client-react
+# cp ../.env.example .env # 환경 변수 설정
 # npm install && npm run dev
 ```
+
+`.env` 파일의 `VITE_API_URL` 값은 백엔드 Web API의 기본 주소를 가리켜야 합니다.
 
 현재 환경에서는 .NET SDK가 설치되어 있지 않으므로 `dotnet` 명령이 실행되지 않을 수 있습니다.

--- a/client-react/src/hooks/usePosts.ts
+++ b/client-react/src/hooks/usePosts.ts
@@ -11,7 +11,7 @@ export function usePosts() {
   const [posts, setPosts] = useState<Post[]>([]);
 
   useEffect(() => {
-    fetch("https://localhost:52015/api/posts")
+    fetch(`${import.meta.env.VITE_API_URL}/api/posts`)
       .then((res) => res.json() as Promise<Post[]>)
       .then(setPosts);
   }, []);


### PR DESCRIPTION
## Summary
- use VITE_API_URL env var in React posts hook
- document VITE_API_URL usage and add .env.example

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'prop-types')*


------
https://chatgpt.com/codex/tasks/task_b_68b72c585ab0832fb49248f834c28b85